### PR TITLE
Add basic model for FontFamily, FontStyle

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,7 @@ func ReadProjectFile(path string) *model.ProjectFile {
 		return nil
 	}
 
-	var projectFile model.ProjectFile 
+	var projectFile model.ProjectFile
 
 	if parseErr := yaml.Unmarshal(contents, &projectFile); parseErr != nil {
 		log.Print(parseErr)

--- a/pkg/model/font.go
+++ b/pkg/model/font.go
@@ -1,0 +1,21 @@
+package model
+
+type FontFormat string
+
+const (
+	OTF FontFormat = "otf"
+	TTF            = "ttf"
+	TTC            = "ttc"
+)
+
+type FontFamily struct {
+	Name     string
+	Styles   []FontStyle
+	Language string
+}
+
+type FontStyle struct {
+	Name   string
+	Path   string
+	Format FontFormat
+}

--- a/pkg/model/project.go
+++ b/pkg/model/project.go
@@ -1,11 +1,11 @@
 package model
 
 type ProjectFont struct {
-	Name string `yaml:"name"`
+	Name   string   `yaml:"name"`
 	Styles []string `yaml:"styles"`
 }
 
 type ProjectFile struct {
-	Name string `yaml:"name"` 
+	Name  string        `yaml:"name"`
 	Fonts []ProjectFont `yaml:"fonts"`
 }


### PR DESCRIPTION
These changes simply add a (basic) model for interfacing with `FontFamilies` and `FontStyles`. These are subject to change, but give us a jumping-off point for implementing the parser and other systems.
