### PR TITLE
Added `fc-list` line parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,18 @@ go 1.19
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/goccy/go-yaml v1.9.5 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	github.com/stretchr/objx v0.4.0 // indirect
+	github.com/stretchr/testify v1.8.0 // indirect
 	github.com/urfave/cli/v2 v2.16.3 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
@@ -19,11 +21,17 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/urfave/cli/v2 v2.16.3 h1:gHoFIwpPjoyIMbJp/VFd+/vuD0dAgFK4B6DpEMFJfQk=
 github.com/urfave/cli/v2 v2.16.3/go.mod h1:1CNUng3PtjQMtRzJO4FMXBQvkGtuYRxxiR9xMa7jMwI=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
@@ -47,3 +55,6 @@ golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3j
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2/go.mod h1:K8+ghG5WaK9qNqU5K3HdILfMLy1f3aNYFI/wnl100a8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/model/font.go
+++ b/pkg/model/font.go
@@ -1,11 +1,10 @@
 package model
 
-type FontFormat string
-
 const (
-	OTF FontFormat = "otf"
-	TTF            = "ttf"
-	TTC            = "ttc"
+	OTF  string = "otf"
+	TTF         = "ttf"
+	TTC         = "ttc"
+	NONE        = "none"
 )
 
 type FontFamily struct {
@@ -17,5 +16,5 @@ type FontFamily struct {
 type FontStyle struct {
 	Name   string
 	Path   string
-	Format FontFormat
+	Format string
 }

--- a/pkg/parser/list.go
+++ b/pkg/parser/list.go
@@ -2,11 +2,15 @@ package parser
 
 import (
 	"fontman/client/pkg/model"
+	"path/filepath"
 	"strings"
 )
 
+/*
+	Split the line into three sections: path, family name, and styles
+*/
 func SplitSections(line string) []string {
-	sections := strings.Split(line, ":")
+	sections := strings.Split(strings.TrimSpace(line), ":")
 
 	for i, section := range sections {
 		sections[i] = strings.TrimSpace(section)
@@ -15,25 +19,51 @@ func SplitSections(line string) []string {
 	return sections
 }
 
+func ParseListLines(lines string) []model.FontFamily {
+	families := []model.FontFamily{}
+
+	for _, line := range strings.Split(lines, "\n") {
+		families = append(families, ParseListLine(line))
+	}
+
+	return families
+}
+
+/*
+	Split all families into a list of names
+*/
+func ParseFamilyNames(fullName string) []string {
+	return strings.Split(fullName, ",")
+}
+
+/*
+	Parse a line into a FontFamily model
+*/
 func ParseListLine(line string) model.FontFamily {
 	sections := SplitSections(line)
 
-	// path := sections[0]
-	styles := ParseStyles(sections[2])
+	path := sections[0]
+	fontFamilyNames := ParseFamilyNames(sections[1])
+	fontFormat := filepath.Ext(path)
+	styles := ParseStyles(path, fontFormat, sections[2])
 
 	return model.FontFamily{
-		Name: "family",
-		Styles: styles,
+		Name:     fontFamilyNames[0],
+		Styles:   styles,
 		Language: "en",
 	}
 }
 
-func ParseFontPath(path string) {
+/*
+	Parse a style section into FontStyle models
+*/
+func ParseStyles(filePath string, fileFormat string, styles string) []model.FontStyle {
+	styleNames := strings.Split(strings.TrimLeft(styles, "style="), ",")
+	var fontStyles []model.FontStyle
 
-}
+	for _, name := range styleNames {
+		fontStyles = append(fontStyles, model.FontStyle{Name: name, Path: filePath, Format: fileFormat})
+	}
 
-func ParseStyles(path string, styles string) []model.FontStyle {
-	styleNames := strings.Split(strings.Trim(styles, "style="), ",")
-
-	
+	return fontStyles
 }

--- a/pkg/parser/list.go
+++ b/pkg/parser/list.go
@@ -8,6 +8,8 @@ import (
 
 /*
 	Split the line into three sections: path, family name, and styles
+
+	<path>:<family>,<family-alt>,...:<style>,<style>,...
 */
 func SplitSections(line string) []string {
 	sections := strings.Split(strings.TrimSpace(line), ":")
@@ -19,8 +21,12 @@ func SplitSections(line string) []string {
 	return sections
 }
 
+/*
+	Given a string of lines (each line -> one font family definition), parse
+	them and return a list of FontFamily models
+*/
 func ParseListLines(lines string) []model.FontFamily {
-	families := []model.FontFamily{}
+	var families []model.FontFamily
 
 	for _, line := range strings.Split(lines, "\n") {
 		families = append(families, ParseListLine(line))
@@ -47,6 +53,7 @@ func ParseListLine(line string) model.FontFamily {
 	fontFormat := filepath.Ext(path)
 	styles := ParseStyles(path, fontFormat, sections[2])
 
+	// TODO: by default, we're only parsing the English (en) version. Potentially we could load in all languages.
 	return model.FontFamily{
 		Name:     fontFamilyNames[0],
 		Styles:   styles,

--- a/pkg/parser/list.go
+++ b/pkg/parser/list.go
@@ -1,0 +1,39 @@
+package parser
+
+import (
+	"fontman/client/pkg/model"
+	"strings"
+)
+
+func SplitSections(line string) []string {
+	sections := strings.Split(line, ":")
+
+	for i, section := range sections {
+		sections[i] = strings.TrimSpace(section)
+	}
+
+	return sections
+}
+
+func ParseListLine(line string) model.FontFamily {
+	sections := SplitSections(line)
+
+	// path := sections[0]
+	styles := ParseStyles(sections[2])
+
+	return model.FontFamily{
+		Name: "family",
+		Styles: styles,
+		Language: "en",
+	}
+}
+
+func ParseFontPath(path string) {
+
+}
+
+func ParseStyles(path string, styles string) []model.FontStyle {
+	styleNames := strings.Split(strings.Trim(styles, "style="), ",")
+
+	
+}

--- a/pkg/parser/list_test.go
+++ b/pkg/parser/list_test.go
@@ -1,15 +1,33 @@
 package parser_test
 
 import (
-	"testing"
 	"fontman/client/pkg/parser"
+	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
-func TestLineParse(t *testing.T) {
+func TestSectionParse(t *testing.T) {
 	input := "/test/path/font.ttf: Test Font:style=Regular,Italics"
 	sections := parser.SplitSections(input)
 
 	if len(sections) != 3 {
 		t.Errorf("Got %d sections, expected 3.", len(sections))
+	}
+}
+
+func TestLineParse(t *testing.T) {
+	input := `/Users/gmisail/Library/Fonts/Ubuntu Mono derivative Powerline Bold Italic.ttf: Ubuntu Mono derivative Powerline:style=Bold Italic
+		/opt/X11/share/fonts/75dpi/courO24-ISO8859-1.pcf.gz: Courier:style=Oblique
+		/opt/X11/share/fonts/75dpi/helvO14-ISO8859-1.pcf.gz: Helvetica:style=Oblique
+		/opt/X11/share/fonts/75dpi/helvO24-ISO8859-1.pcf.gz: Helvetica:style=Oblique
+		/opt/X11/share/fonts/misc/18x18ko.pcf.gz: Fixed:style=ko`
+	families := parser.ParseListLines(input)
+	expectedNames := []string{"Ubuntu Mono derivative Powerline", "Courier", "Helvetica", "Helvetica", "Fixed"}
+
+	assert.Equal(t, 5, len(families))
+
+	for i, name := range expectedNames {
+		actualName := families[i].Name
+		assert.Equal(t, name, actualName)
 	}
 }

--- a/pkg/parser/list_test.go
+++ b/pkg/parser/list_test.go
@@ -1,0 +1,15 @@
+package parser_test
+
+import (
+	"testing"
+	"fontman/client/pkg/parser"
+)
+
+func TestLineParse(t *testing.T) {
+	input := "/test/path/font.ttf: Test Font:style=Regular,Italics"
+	sections := parser.SplitSections(input)
+
+	if len(sections) != 3 {
+		t.Errorf("Got %d sections, expected 3.", len(sections))
+	}
+}


### PR DESCRIPTION
These changes add a parser for `fc-list` given the following command: `fc-list : file family style`. In other words, it will parse the output of the command and return a list of FontFamily & FontStyle models. 

There is a unit test that tests this functionality on a limited data set (only 4 or 5 lines). Some more tested is needed, but it *should* parse fine given the actual `fc-list` output. 

