### PR TITLE
Install local fonts to user directory

### DIFF
--- a/cmd/fontman/commands/install.go
+++ b/cmd/fontman/commands/install.go
@@ -1,16 +1,23 @@
 package commands
 
 import (
-	"fmt"
-
+	"fontman/client/pkg/font"
 	"github.com/urfave/cli/v2"
 )
 
 // Called if 'install' subcommand is invoked.
-func onInstall(c *cli.Context) error {
-	fmt.Println("Installing font(s)...")
+func onInstall(c *cli.Context, style string, global bool) error {
+	fileName := c.Args().Get(0)
 
-	return nil
+	// no arguments, install from local file
+	if len(fileName) == 0 {
+		// TODO: return font.InstallFromFile()
+		return nil
+	}
+
+	// TODO: try to install from remote
+
+	return font.InstallFont(fileName, global)
 }
 
 // Constructs the 'install' subcommand.
@@ -19,9 +26,11 @@ func RegisterInstall() *cli.Command {
 	var global bool
 
 	return &cli.Command{
-		Name:   "install",
-		Usage:  "Install a font given its identifier in the registry.",
-		Action: onInstall,
+		Name:  "install",
+		Usage: "Install a font given its identifier in the registry.",
+		Action: func(context *cli.Context) error {
+			return onInstall(context, style, global)
+		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:        "style",

--- a/pkg/font/installer.go
+++ b/pkg/font/installer.go
@@ -1,0 +1,28 @@
+package font
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+type InstallationError struct {
+	message string
+}
+
+// TODO: replace with a standard error format
+func (i InstallationError) Error() string {
+	panic(i.message)
+}
+
+func validateFormat(file string) bool {
+	fileType := filepath.Ext(file)
+	return fileType == "ttf" || fileType == "otf" || fileType == "ttc"
+}
+
+func InstallFont(file string) error {
+	if !validateFormat(file) {
+		return &InstallationError{
+			message: fmt.Sprintf("Cannot install font with unsupported format '%s'.", filepath.Ext(file)),
+		}
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 func Cache(verbose bool, force bool) error {
@@ -46,4 +47,14 @@ func SetupFolders() error {
 		}
 	}
 	return nil
+}
+
+func GetInstallationPath() string {
+	dir, err := os.UserHomeDir()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return filepath.Join(dir, "/.fontman")
 }


### PR DESCRIPTION
These changes add the ability to install a local font to the user's font directory (`~/.fontman`). It will check to see if the file that you're installing both exists & is a supported format. If so, it'll move it to the installation directory and regenerate the cache.