### PR TITLE
List all fonts

### DIFF
--- a/cmd/fontman/commands/install.go
+++ b/cmd/fontman/commands/install.go
@@ -1,11 +1,11 @@
 package commands
 
 import (
-	"fmt"
-  "fontman/client/pkg/font"
-	"fontman/client/pkg/util"
-	"log"
+	//	"fmt"
+	"fontman/client/pkg/font"
+	//	"fontman/client/pkg/util"
 	"github.com/urfave/cli/v2"
+	// "log"
 )
 
 // Called if 'install' subcommand is invoked.

--- a/cmd/fontman/commands/list.go
+++ b/cmd/fontman/commands/list.go
@@ -6,6 +6,7 @@ import (
 	"fontman/client/pkg/util"
 	"log"
 	"sort"
+	"strings"
 
 	"github.com/urfave/cli/v2"
 )
@@ -34,8 +35,26 @@ func onList(c *cli.Context, style string, global bool) error {
 		return allFonts[i].Name < allFonts[j].Name
 	})
 
+	b := strings.Builder{}
 	for _, font := range allFonts {
-		fmt.Println(font.Name, font.Language, font.Styles)
+		b.Reset()
+
+		b.WriteString(font.Name)
+		b.WriteString(" ")
+		b.WriteString(font.Language)
+		b.WriteString(" (")
+
+		for i, style := range font.Styles {
+			b.WriteString(style.Name)
+
+			if len(font.Styles)-1 != i {
+				b.WriteString(", ")
+			}
+		}
+
+		b.WriteString(")")
+
+		fmt.Println(b.String())
 	}
 
 	return nil

--- a/cmd/fontman/commands/list.go
+++ b/cmd/fontman/commands/list.go
@@ -2,8 +2,10 @@ package commands
 
 import (
 	"fmt"
+	"fontman/client/pkg/parser"
 	"fontman/client/pkg/util"
 	"log"
+	"sort"
 
 	"github.com/urfave/cli/v2"
 )
@@ -14,9 +16,27 @@ func onList(c *cli.Context, style string, global bool) error {
 
 	if err != nil {
 		log.Fatal(err)
+
+		return err
 	}
 
-	fmt.Println("Listing installed font(s)...")
+	listOut, listOutErr := util.ListAll()
+
+	if listOutErr != nil {
+		log.Fatal(listOutErr)
+
+		return listOutErr
+	}
+
+	allFonts := parser.ParseListLines(listOut)
+
+	sort.Slice(allFonts, func(i, j int) bool {
+		return allFonts[i].Name < allFonts[j].Name
+	})
+
+	for _, font := range allFonts {
+		fmt.Println(font.Name, font.Language, font.Styles)
+	}
 
 	return nil
 }

--- a/pkg/parser/list.go
+++ b/pkg/parser/list.go
@@ -1,15 +1,16 @@
 package parser
 
 import (
+	//	"fmt"
 	"fontman/client/pkg/model"
 	"path/filepath"
 	"strings"
 )
 
 /*
-	Split the line into three sections: path, family name, and styles
+Split the line into three sections: path, family name, and styles
 
-	<path>:<family>,<family-alt>,...:<style>,<style>,...
+<path>:<family>,<family-alt>,...:<style>,<style>,...
 */
 func SplitSections(line string) []string {
 	sections := strings.Split(strings.TrimSpace(line), ":")
@@ -22,39 +23,51 @@ func SplitSections(line string) []string {
 }
 
 /*
-	Given a string of lines (each line -> one font family definition), parse
-	them and return a list of FontFamily models
+Given a string of lines (each line -> one font family definition), parse
+them and return a list of FontFamily models
 */
-func ParseListLines(lines string) []model.FontFamily {
-	var families []model.FontFamily
+func ParseListLines(lines string) []*model.FontFamily {
+	var families []*model.FontFamily
 
 	for _, line := range strings.Split(lines, "\n") {
-		families = append(families, ParseListLine(line))
+		currentFamily := ParseListLine(line)
+
+		if currentFamily != nil {
+			families = append(families, ParseListLine(line))
+		}
 	}
 
 	return families
 }
 
 /*
-	Split all families into a list of names
+Split all families into a list of names
 */
 func ParseFamilyNames(fullName string) []string {
 	return strings.Split(fullName, ",")
 }
 
 /*
-	Parse a line into a FontFamily model
+Parse a line into a FontFamily model
 */
-func ParseListLine(line string) model.FontFamily {
+func ParseListLine(line string) *model.FontFamily {
+	if len(line) == 0 {
+		return nil
+	}
+
 	sections := SplitSections(line)
 
 	path := sections[0]
 	fontFamilyNames := ParseFamilyNames(sections[1])
 	fontFormat := filepath.Ext(path)
-	styles := ParseStyles(path, fontFormat, sections[2])
+	styles := []model.FontStyle{}
+
+	if len(sections) > 2 {
+		ParseStyles(path, fontFormat, sections[2])
+	}
 
 	// TODO: by default, we're only parsing the English (en) version. Potentially we could load in all languages.
-	return model.FontFamily{
+	return &model.FontFamily{
 		Name:     fontFamilyNames[0],
 		Styles:   styles,
 		Language: "en",
@@ -62,7 +75,7 @@ func ParseListLine(line string) model.FontFamily {
 }
 
 /*
-	Parse a style section into FontStyle models
+Parse a style section into FontStyle models
 */
 func ParseStyles(filePath string, fileFormat string, styles string) []model.FontStyle {
 	styleNames := strings.Split(strings.TrimLeft(styles, "style="), ",")

--- a/pkg/parser/list.go
+++ b/pkg/parser/list.go
@@ -63,7 +63,7 @@ func ParseListLine(line string) *model.FontFamily {
 	styles := []model.FontStyle{}
 
 	if len(sections) > 2 {
-		ParseStyles(path, fontFormat, sections[2])
+		styles = ParseStyles(path, fontFormat, sections[2])
 	}
 
 	// TODO: by default, we're only parsing the English (en) version. Potentially we could load in all languages.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -32,6 +32,19 @@ func Cache(verbose bool, force bool) error {
 	return nil
 }
 
+func ListAll() (string, error) {
+	cmd := exec.Command("fc-list", ":", "family", "style", "file")
+	output, outputErr := cmd.Output()
+
+	if outputErr != nil {
+		log.Fatal(outputErr)
+
+		return "", outputErr
+	}
+
+	return string(output), nil
+}
+
 func SetupFolders(global bool) error {
 	// create fontman folder in .config if it doesn't exist
 	configDir, err := os.UserConfigDir()


### PR DESCRIPTION
Finishes up a working version (on Linux at least) of the `fontman list` command. In this version we have ignored languages, 
and instead focused on showing all *unique* font families and their styles. 
