### PR TITLE
Download fonts from remote

### DIFF
--- a/cmd/fontman/commands/install.go
+++ b/cmd/fontman/commands/install.go
@@ -34,7 +34,7 @@ func onInstall(c *cli.Context, style string, excludeStyle string, global bool) e
 		return font.InstallFont(fileName, global)
 	}
 
-	return font.InstallFromRemote("608308d7-5f72-45f4-9776-a99a692703d6")
+	return font.InstallFromRemote("3cc5af2a-0fbd-4190-9889-e527abaf7df8")
 }
 
 // Constructs the 'install' subcommand.

--- a/pkg/api/font.go
+++ b/pkg/api/font.go
@@ -12,12 +12,12 @@ import (
 // TODO: load this from a remotes config variable, so: remotes: [ registry.fontman.io, http://196.1668... ]
 var BASE_URL string = "http://127.0.0.1:8080"
 
+// DownloadFrom: downloads file from 'url' and saves it as 'dest`
 func DownloadFrom(url string, dest string) error {
-	// response, err := http.Get("https://github.com/google/fonts/raw/main/ofl/anonymouspro/AnonymousPro-Bold.ttf")
-	response, err := http.Get(url)
+	response, resErr := http.Get(url)
 
-	if err != nil {
-		return err
+	if resErr != nil {
+		return resErr
 	}
 
 	defer response.Body.Close()
@@ -31,6 +31,7 @@ func DownloadFrom(url string, dest string) error {
 	return os.WriteFile(dest, contents, 0777)
 }
 
+// GetFontDetails: return details for a font with ID
 func GetFontDetails(id string) (*model.RemoteFontFamily, error) {
 	url := fmt.Sprintf("%s/api/font/%s", BASE_URL, id)
 	response, getErr := http.Get(url)
@@ -60,7 +61,7 @@ func GetFontDetails(id string) (*model.RemoteFontFamily, error) {
 	for _, style := range font.Styles {
 		dest := fmt.Sprintf("%s-%s.%s", font.Name, style.Type, "ttf")
 
-		if err := DownloadFrom(fmt.Sprintf("http://%s", style.Url), dest); err != nil {
+		if err := DownloadFrom(style.Url, dest); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/font/installer.go
+++ b/pkg/font/installer.go
@@ -70,7 +70,7 @@ func InstallFont(file string, isGlobal bool) error {
 }
 
 func InstallFromRemote(id string) error {
-	remoteFont, remoteErr := api.GetFontDetails("608308d7-5f72-45f4-9776-a99a692703d6")
+	remoteFont, remoteErr := api.GetFontDetails(id)
 
 	if remoteErr != nil {
 		return remoteErr

--- a/pkg/parser/list.go
+++ b/pkg/parser/list.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	//	"fmt"
 	"fontman/client/pkg/model"
 	"path/filepath"
 	"strings"


### PR DESCRIPTION
This pull request adds the functionality to download files from a 
remote repository. For now, we are only downloading from `localhost:8080`; 
in the future, we will load paths from the configuration file (`api.fontman.io` or something).

I've accidentally pushed some of code already, so I'm going to skip a review for this once
especially since it's not in a state where things are completely integrated. A more detailed
review is required when we actually implement *installing* from remote.
