### PR TITLE
Refactor download logic

### DIFF
--- a/pkg/api/font.go
+++ b/pkg/api/font.go
@@ -6,30 +6,10 @@ import (
 	"fontman/client/pkg/model"
 	"io/ioutil"
 	"net/http"
-	"os"
 )
 
 // TODO: load this from a remotes config variable, so: remotes: [ registry.fontman.io, http://196.1668... ]
 var BASE_URL string = "http://127.0.0.1:8080"
-
-// DownloadFrom: downloads file from 'url' and saves it as 'dest`
-func DownloadFrom(url string, dest string) error {
-	response, resErr := http.Get(url)
-
-	if resErr != nil {
-		return resErr
-	}
-
-	defer response.Body.Close()
-
-	contents, readErr := ioutil.ReadAll(response.Body)
-
-	if readErr != nil {
-		return readErr
-	}
-
-	return os.WriteFile(dest, contents, 0777)
-}
 
 // GetFontDetails: return details for a font with ID
 func GetFontDetails(id string) (*model.RemoteFontFamily, error) {
@@ -55,15 +35,6 @@ func GetFontDetails(id string) (*model.RemoteFontFamily, error) {
 
 	if parseErr != nil {
 		return nil, parseErr
-	}
-
-	// download each style to a file with name: <family>-<style>.<format>
-	for _, style := range font.Styles {
-		dest := fmt.Sprintf("%s-%s.%s", font.Name, style.Type, "ttf")
-
-		if err := DownloadFrom(style.Url, dest); err != nil {
-			return nil, err
-		}
 	}
 
 	return &font, nil


### PR DESCRIPTION
Very small change, simply move some of the download logic out of the API controller. This change keeps the data flow consistent, i.e. the download logic is *not* intertwined with the installation logic.
