### PR TITLE
Download font based on user selection

### DIFF
--- a/cmd/fontman/commands/list.go
+++ b/cmd/fontman/commands/list.go
@@ -14,8 +14,8 @@ import (
 )
 
 /*
-	Given a list of fonts, combine them by family name. Returns a list of the
-	formatted font names as well as a mapping of font name to family.
+Given a list of fonts, combine them by family name. Returns a list of the
+formatted font names as well as a mapping of font name to family.
 */
 func showUnique(fonts []*model.FontFamily) ([]string, map[string][]string) {
 	// family => list of unique styles

--- a/pkg/api/font.go
+++ b/pkg/api/font.go
@@ -39,3 +39,30 @@ func GetFontDetails(id string) (*model.RemoteFontFamily, error) {
 
 	return &font, nil
 }
+
+func GetFontOptions(name string) ([]model.RemoteFontFamily, error) {
+	url := fmt.Sprintf("%s/api/font?name=%s", BASE_URL, name)
+	response, getErr := http.Get(url)
+
+	if getErr != nil {
+		return nil, getErr
+	}
+
+	defer response.Body.Close()
+
+	// read response to byte array
+	body, bodyErr := ioutil.ReadAll(response.Body)
+
+	if bodyErr != nil {
+		return nil, bodyErr
+	}
+
+	var fonts model.RemoteFontList
+	parseErr := json.Unmarshal(body, &fonts)
+
+	if parseErr != nil {
+		return nil, parseErr
+	}
+
+	return fonts.Fonts, nil
+}

--- a/pkg/model/font.go
+++ b/pkg/model/font.go
@@ -19,6 +19,10 @@ type FontStyle struct {
 	Format string
 }
 
+type RemoteFontList struct {
+	Fonts []RemoteFontFamily `json:"fonts"`
+}
+
 type RemoteFontFamily struct {
 	Id     string            `json:"id"`
 	Name   string            `json:"name"`


### PR DESCRIPTION
This is the client-side change for a patch that I made earlier this week on the registry-side.

When a user runs: `fontman install IBM`, we send "IBM" over to the registry. In turn, the registry sends back a list of 
options that "IBM" applies to. These changes will render a list of these options, scan for a selection from the user,
and then download fonts based on their selection.

## Example
<img width="697" alt="image" src="https://user-images.githubusercontent.com/8661089/205382042-ed9b03d4-fc75-40bf-8bef-0bbe479ff6cb.png">

