### PR TITLE
Replace spaces with '-' on download

### DIFF
--- a/pkg/font/installer.go
+++ b/pkg/font/installer.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func validateFormat(file string) bool {
@@ -84,7 +85,10 @@ func InstallFromRemote(id string) error {
 
 	// download each style to a file with name: <family>-<style>.<format>
 	for _, style := range font.Styles {
-		dest := fmt.Sprintf("%s-%s.%s", font.Name, style.Type, "ttf")
+		// replace spaces with '-' to prevent any filepath issues
+		normalizedName := strings.ReplaceAll(font.Name, " ", "-")
+
+		dest := fmt.Sprintf("%s-%s.%s", normalizedName, style.Type, "ttf")
 
 		if err := DownloadFrom(style.Url, dest); err != nil {
 			return err


### PR DESCRIPTION
This quick patch will ensure that when downloading files, their names do *not* have spaces. This is to prevent any wonky behavior related to moving files with spaces.