### PR TITLE
Install fonts from remote

### DIFF
--- a/cmd/fontman/commands/install.go
+++ b/cmd/fontman/commands/install.go
@@ -81,7 +81,7 @@ func onInstall(c *cli.Context, style string, excludeStyle string, global bool) e
 		return errors.New(fmt.Sprintf("No fonts found with name '%s'", fileName))
 	}
 
-	return font.InstallFromRemote(selectedId)
+	return font.InstallFromRemote(selectedId, global)
 }
 
 // Constructs the 'install' subcommand.

--- a/cmd/fontman/commands/install.go
+++ b/cmd/fontman/commands/install.go
@@ -11,7 +11,6 @@ import (
 	"fontman/client/pkg/util"
 	"path/filepath"
 
-	"github.com/fatih/color"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cmd/fontman/commands/install.go
+++ b/cmd/fontman/commands/install.go
@@ -11,6 +11,7 @@ import (
 	"fontman/client/pkg/util"
 	"path/filepath"
 
+	"github.com/fatih/color"
 	"github.com/urfave/cli/v2"
 )
 
@@ -52,14 +53,14 @@ func onInstall(c *cli.Context, style string, excludeStyle string, global bool) e
 
 	// no arguments: install from local `fontman.yml` file
 	if len(fileName) == 0 {
-		fmt.Println("fetching from fontman.yml file...")
+		fmt.Println("TODO: Fetch from fontman.yml file...")
 		return nil
 	}
 
-	// test.ttf: local fille, test: remote file
+	// test.ttf: local file, test: remote file
 	ext := filepath.Ext(fileName)
 
-	// if there's an extension, then we're trying to install from loccal
+	// if there's an extension, then we're trying to install from local
 	if len(ext) != 0 {
 		return font.InstallFont(fileName, global)
 	}
@@ -76,8 +77,10 @@ func onInstall(c *cli.Context, style string, excludeStyle string, global bool) e
 			return errors.New(fmt.Sprintf("Invalid option selected."))
 		}
 	} else if len(options) == 1 {
+		// if there is only one option, don't bother presenting options
 		selectedId = options[0].Id
 	} else {
+		// no options, throw error
 		return errors.New(fmt.Sprintf("No fonts found with name '%s'", fileName))
 	}
 
@@ -95,7 +98,13 @@ func RegisterInstall() *cli.Command {
 		Name:  "install",
 		Usage: "Install a font given its identifier in the registry.",
 		Action: func(c *cli.Context) error {
-			return onInstall(c, style, excludeStyle, global)
+			err := onInstall(c, style, excludeStyle, global)
+
+			if err != nil {
+				cli.Exit(err.Error(), 1)
+			}
+
+			return nil
 		},
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/pkg/font/installer.go
+++ b/pkg/font/installer.go
@@ -71,7 +71,7 @@ func InstallFont(file string, isGlobal bool) error {
 		return cacheErr
 	}
 
-	fmt.Printf("Successfully installed '%s' to %s! 🎉\n", fileName, installPath)
+	fmt.Printf("Successfully installed '%s' to '%s'!\n", fileName, installPath)
 
 	return nil
 }
@@ -88,9 +88,18 @@ func InstallFromRemote(id string) error {
 		// replace spaces with '-' to prevent any filepath issues
 		normalizedName := strings.ReplaceAll(font.Name, " ", "-")
 
+		// TODO: replace this with temp path in ~/.fontman
 		dest := fmt.Sprintf("%s-%s.%s", normalizedName, style.Type, "ttf")
 
+		// download the font to the working directory
 		if err := DownloadFrom(style.Url, dest); err != nil {
+			return err
+		}
+
+		// TODO: pass down isGlobal flag
+
+		// install the font to the system
+		if err := InstallFont(dest, false); err != nil {
 			return err
 		}
 	}

--- a/pkg/font/installer.go
+++ b/pkg/font/installer.go
@@ -76,7 +76,7 @@ func InstallFont(file string, isGlobal bool) error {
 	return nil
 }
 
-func InstallFromRemote(id string) error {
+func InstallFromRemote(id string, isGlobal bool) error {
 	font, err := api.GetFontDetails(id)
 
 	if err != nil {
@@ -95,8 +95,6 @@ func InstallFromRemote(id string) error {
 		if err := DownloadFrom(style.Url, dest); err != nil {
 			return err
 		}
-
-		// TODO: pass down isGlobal flag
 
 		// install the font to the system
 		if err := InstallFont(dest, false); err != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -189,12 +189,10 @@ func GetFontFolder(isGlobal bool) (string, error) {
 		}
 		// TODO: .local/share/fonts/fontman/_family_name_/
 		for i := 0; i < len(userPaths); i++ {
-			fmt.Println(userPaths[i])
 			if _, err := os.Stat(userPaths[i]); err == nil {
 				// TODO: actually make the fontman directory
 				installPath := filepath.Join(userPaths[i], "fontman")
 				// TODO: confirmation prompt here
-				fmt.Println("Installing to", installPath)
 				return installPath, nil
 			}
 		}


### PR DESCRIPTION
These changes will download fonts from remote into the working directory and then install them directly instead of downloading to a temporary directory first. Mostly just for proof-of-concept purposes, in the future it will be trivial to update this to use a temporary "test bed" directory.

## Output
```
➜  fontman-client git:(download-remote-fonts) ✗ task run -- install IBM
task: [lint] gofmt -w .
task: [build] go build -o ./bin/fontman ./cmd/fontman
task: [run] ./bin/fontman install IBM
Successfully installed 'IBM-Plex-Mono-Regular.ttf' to '/home/gmisail/.local/share/fonts/fontman'!
Successfully installed 'IBM-Plex-Mono-Italic.ttf' to '/home/gmisail/.local/share/fonts/fontman'!
Successfully installed 'IBM-Plex-Mono-Bold.ttf' to '/home/gmisail/.local/share/fonts/fontman'!
Successfully installed 'IBM-Plex-Mono-Thin.ttf' to '/home/gmisail/.local/share/fonts/fontman'!
➜  fontman-client git:(download-remote-fonts) ✗ 
```