### PR TITLE
Install from Project File

### DIFF
--- a/cmd/fontman/commands/install.go
+++ b/cmd/fontman/commands/install.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"fontman/client/pkg/api"
+	"fontman/client/pkg/config"
 	"fontman/client/pkg/font"
 	"fontman/client/pkg/model"
 	"fontman/client/pkg/util"
@@ -52,7 +53,21 @@ func onInstall(c *cli.Context, style string, excludeStyle string, global bool) e
 
 	// no arguments: install from local `fontman.yml` file
 	if len(fileName) == 0 {
-		fmt.Println("TODO: Fetch from fontman.yml file...")
+		project := config.ReadProjectFile("fontman.yml")
+
+		for _, projectFont := range project.Fonts {
+			options, _ := api.GetFontOptions(projectFont.Name)
+
+			// TODO: have user select which they'd like to download
+			if len(options) != 0 {
+				if err := font.InstallFromRemote(options[0].Id, global); err != nil {
+					return err
+				}
+			} else {
+				fmt.Printf("Can't find font with name '%s', ignoring.\n", projectFont.Name)
+			}
+		}
+
 		return nil
 	}
 

--- a/cmd/fontman/commands/install.go
+++ b/cmd/fontman/commands/install.go
@@ -78,6 +78,7 @@ func onInstall(c *cli.Context, style string, excludeStyle string, global bool) e
 
 	// no arguments: install from local `fontman.yml` file
 	if len(fileName) == 0 {
+		// TODO: add multiple options, i.e. fontman.yaml, FontmanFile
 		project := config.ReadProjectFile("fontman.yml")
 
 		// for each font, try to install from remote

--- a/docs/slides-f22.md
+++ b/docs/slides-f22.md
@@ -21,6 +21,7 @@ manager for fonts as well?
 ## Team
 
 - Graham Misail (Project Lead)
+- David Kim
 
 ---
 
@@ -115,7 +116,20 @@ fontman install
 
 ## Next Steps
 
-TBD.
+- User authentication
+  - Who can upload fonts?
+- `upload` command
+  - Add uploading from a file, instead of a REST endpoint
+- Font analytics
+  - Number of downloads, recently updated, etc...
+- I know it's a CLI app, but...
+  - Visual polish, clean up the interface
+  - Rewrite the visuals to use **BubbleTea**, a TUI framework
+- Web interface
+  - Similar to `npmjs.com` or `aur.archlinux.org`
+  - Browse & preview fonts
+  - Provide a download command
+    - `fontman install <UUID> <UUID> …`
 
 ---
 


### PR DESCRIPTION
These changes piggyback off of the "install from remote" changes. The only difference is the font names are fed via a file, not as a command-line argument. As part of this, the "remote installation" code in `install.go`  was abstracted into a separate function.

## Example
```
➜  fontman-client git:(install-from-yaml) ✗ task run -- install
task: [lint] gofmt -w .
task: [build] go build -o ./bin/fontman ./cmd/fontman
task: [run] ./bin/fontman install
No font found with name 'Inconsolata'
1) IBM Plex Mono [c9e6e0bd-924f-4e4a-b53b-9a084729047e]
2) IBM Plex Mono [714c0f2b-917e-42af-9eab-176652e8c538]

Select an option to install [1 - 2]:
2
Successfully installed 'IBM-Plex-Mono-Regular.ttf' to '/home/gmisail/.local/share/fonts/fontman'!
Successfully installed 'IBM-Plex-Mono-Italic.ttf' to '/home/gmisail/.local/share/fonts/fontman'!
Successfully installed 'IBM-Plex-Mono-Bold.ttf' to '/home/gmisail/.local/share/fonts/fontman'!
Successfully installed 'IBM-Plex-Mono-Thin.ttf' to '/home/gmisail/.local/share/fonts/fontman'!
```