### PR TITLE
Write errors to STDERR

### DIFF
--- a/cmd/fontman/commands/install.go
+++ b/cmd/fontman/commands/install.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 
 	"fontman/client/pkg/api"
@@ -102,7 +101,11 @@ func onInstall(c *cli.Context, style string, excludeStyle string, global bool) e
 	// no arguments: install from local `fontman.yml` file
 	if len(fileName) == 0 {
 		// TODO: add multiple options, i.e. fontman.yaml, FontmanFile
-		project := config.ReadProjectFile("fontman.yml")
+		project, projectErr := config.ReadProjectFile("fontman.yml")
+
+		if projectErr != nil {
+			return projectErr
+		}
 
 		// for each font, try to install from remote
 		for _, projectFont := range project.Fonts {
@@ -139,8 +142,6 @@ func RegisterInstall() *cli.Command {
 			err := onInstall(c, style, excludeStyle, global)
 
 			if err != nil {
-				log.Fatal(err.Error())
-
 				return err
 			}
 

--- a/cmd/fontman/commands/list.go
+++ b/cmd/fontman/commands/list.go
@@ -5,7 +5,6 @@ import (
 	"fontman/client/pkg/model"
 	"fontman/client/pkg/parser"
 	"fontman/client/pkg/util"
-	"log"
 	"sort"
 	"strings"
 
@@ -68,16 +67,12 @@ func onList(c *cli.Context, style string, global bool) error {
 	err := util.SetupFolders(global)
 
 	if err != nil {
-		log.Fatal(err)
-
 		return err
 	}
 
 	listOut, listOutErr := util.ListAll()
 
 	if listOutErr != nil {
-		log.Fatal(listOutErr)
-
 		return listOutErr
 	}
 

--- a/cmd/fontman/commands/uninstall.go
+++ b/cmd/fontman/commands/uninstall.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"fmt"
 	"fontman/client/pkg/util"
-	"log"
 
 	"github.com/urfave/cli/v2"
 )
@@ -13,8 +12,9 @@ func onUninstall(c *cli.Context, style string, ex_style string, global bool) err
 	err := util.SetupFolders(global)
 
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
+
 	fmt.Println("Uninstalling font(s)...")
 
 	return nil

--- a/cmd/fontman/main.go
+++ b/cmd/fontman/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fontman/client/cmd/fontman/commands"
-	"log"
 	"os"
 
 	"github.com/urfave/cli/v2"
@@ -27,6 +26,7 @@ func main() {
 	err := app.Run(os.Args)
 
 	if err != nil {
-		log.Fatal(err)
+		// write the error to STDERR before quitting
+		os.Stderr.WriteString(err.Error())
 	}
 }

--- a/cmd/fontman/main.go
+++ b/cmd/fontman/main.go
@@ -26,7 +26,7 @@ func main() {
 	err := app.Run(os.Args)
 
 	if err != nil {
-		// write the error to STDERR before quitting
-		os.Stderr.WriteString(err.Error())
+		os.Stderr.WriteString(err.Error() + "\n")
+		os.Exit(1)
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,45 +2,38 @@ package config
 
 import (
 	"fontman/client/pkg/model"
-	"log"
 	"os"
 
 	"github.com/goccy/go-yaml"
 )
 
-func ReadConfigFile(path string) *model.ConfigFile {
+func ReadConfigFile(path string) (*model.ConfigFile, error) {
 	contents, fileErr := os.ReadFile(path)
 
 	if fileErr != nil {
-		log.Println(fileErr)
-		return nil
+		return nil, fileErr
 	}
 
 	configFile := model.ConfigFile{}
 	if parseErr := yaml.Unmarshal(contents, &configFile); parseErr != nil {
-		log.Println(parseErr)
-		return nil
+		return nil, parseErr
 	}
 
-	return &configFile
+	return &configFile, nil
 }
 
-func ReadProjectFile(path string) *model.ProjectFile {
+func ReadProjectFile(path string) (*model.ProjectFile, error) {
 	contents, fileErr := os.ReadFile(path)
 
 	if fileErr != nil {
-		log.Print(fileErr)
-
-		return nil
+		return nil, fileErr
 	}
 
 	var projectFile model.ProjectFile
 
 	if parseErr := yaml.Unmarshal(contents, &projectFile); parseErr != nil {
-		log.Print(parseErr)
-
-		return nil
+		return nil, parseErr
 	}
 
-	return &projectFile
+	return &projectFile, nil
 }

--- a/pkg/errors/installation.go
+++ b/pkg/errors/installation.go
@@ -1,10 +1,15 @@
 package errors
 
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+)
+
 type InstallationError struct {
 	Message string
 }
 
-// TODO: replace with a standard error format
 func (i InstallationError) Error() string {
-	panic(i.Message)
+	return color.RedString(fmt.Sprintf("Installation error: %s", i.Message))
 }

--- a/pkg/errors/installation.go
+++ b/pkg/errors/installation.go
@@ -11,5 +11,5 @@ type InstallationError struct {
 }
 
 func (i InstallationError) Error() string {
-	return color.RedString(fmt.Sprintf("Installation error: %s", i.Message))
+	return fmt.Sprintf("%s %s", color.RedString("Installation error:"), i.Message)
 }

--- a/pkg/errors/permission.go
+++ b/pkg/errors/permission.go
@@ -11,5 +11,5 @@ type PermissionError struct {
 }
 
 func (i PermissionError) Error() string {
-	return color.RedString(fmt.Sprintf("Permission error: %s", i.Message))
+	return fmt.Sprintf("%s %s", color.RedString("Permission error:"), i.Message)
 }

--- a/pkg/errors/permission.go
+++ b/pkg/errors/permission.go
@@ -1,10 +1,15 @@
 package errors
 
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+)
+
 type PermissionError struct {
 	Message string
 }
 
-// TODO: replace with a standard error format
 func (i PermissionError) Error() string {
-	panic(i.Message)
+	return color.RedString(fmt.Sprintf("Permission error: %s", i.Message))
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,11 +1,9 @@
 package util
 
-// we use log for now; should move to a more robust way when commands are finalized.
 import (
 	"errors"
 	"fmt"
 	"fontman/client/pkg/model"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,7 +28,6 @@ func Cache(verbose bool, force bool) error {
 	// pipe output into parser
 
 	if err != nil {
-		log.Fatal(err)
 		return err
 	}
 	return nil
@@ -41,8 +38,6 @@ func ListAll() (string, error) {
 	output, outputErr := cmd.Output()
 
 	if outputErr != nil {
-		log.Fatal(outputErr)
-
 		return "", outputErr
 	}
 
@@ -172,7 +167,6 @@ func SetupFolders(isGlobal bool) error {
 			return err
 		}
 	} else if err != nil {
-		log.Fatal(err)
 		return err
 	}
 


### PR DESCRIPTION
As of now, errors have been spit out into STDOUT or, in some cases, not printed. Now, all errors are written to STDERR if returned by any of the subcommands. So, instead of handling & printing the errors, we just keep passing them up to the top. It will also return an error code of 1 upon failure.